### PR TITLE
FIX: Compatibility with latest Discourse

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -1,5 +1,5 @@
 <!-- JavaScript for clipboard -->
-<script type="text/discourse-plugin" version="0.8">
+<script>
 /*!
  * clipboard.js v2.0.1
  * https://zenorocha.github.io/clipboard.js


### PR DESCRIPTION
As of https://github.com/discourse/discourse/commit/cd24eff5d98e74db4afe0257e4d9de1ad2556c5d, Discourse now executes JavaScript inside `<script type="text/discourse-plugin">` tags in [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode). The minified JS inside this script tag doesn't work with strict mode enabled, but it also doesn't need to be of type `"text/discourse-plugin"`. So to make the component work with latest Discourse, all we have to do is remove `type="text/discourse-plugin" version="0.8"` from the `<script>` tag and this PR does exactly that (the component still works with older versions of Discourse with this change.).